### PR TITLE
Fix indentation to cfset, add cfthread, cftimer, cftrace

### DIFF
--- a/ToScript.cfc
+++ b/ToScript.cfc
@@ -1,6 +1,6 @@
 component {
 	variables.indentLevel = 0;
-	variables.options = {indentChars=Chr(9)};
+	variables.options = {indentChars=Chr(9),cleanTypes=true};
 
 	public struct function toScript(filePath="", options={}, fileContent="") {
 		var codeFile = new cfmlparser.File(filePath=filePath,fileContent=fileContent);

--- a/ToScript.cfc
+++ b/ToScript.cfc
@@ -146,15 +146,19 @@ component {
 	public function getTagConverter(tagName) {
 		var converter = "";
 		try {
-			converter = createObject("component", "converters." & trim(lCase(tagName))).init(options);
+			converter = createObject("component", "converters." & trim(lCase(tagName))).init(options,this);
 		} catch(any e) {
 			if (e.type == "Template") {
 				//due to compiler error of the CFC
 				rethrow;	
 			}
-			converter = createObject("component", "converters.BaseConverter").init(options);
+			converter = createObject("component", "converters.BaseConverter").init(options,this);
 		}
 		return converter;
+	}
+
+	public function getIdentLevel() {
+		return variables.indentLevel;
 	}
 
 	private function lineBreak(sb) {

--- a/converters/BaseConverter.cfc
+++ b/converters/BaseConverter.cfc
@@ -1,12 +1,13 @@
 component {
 	variables.options = {};
-	public function init(options) {
+	public function init(options,toscript) {
 		variables.options = arguments.options;
+		variables.toscript = arguments.toscript;
 		return this;
 	}
 
 	public string function toScript(tag) {
-		if (listFindNoCase("cfcontent,cfcookie,cfheader,cfdbinfo,cfdirectory,cfexecute,cffeed,cffile,cffileupload,cfflush,cfftp,cfimage,cfldap,cflog,cfparam,cfpop,cfprint,cfquery,cfqueryparam,cfprocparam,cfhttp,cfhttpparam,cfoutput,cfinvokeargument,cfsetting,cfprocessingdirective,cfmailparam,cflogout,cfloginuser", tag.getName())) {
+		if (listFindNoCase("cfcontent,cfcookie,cfheader,cfdbinfo,cfdirectory,cfexecute,cffeed,cffile,cffileupload,cfflush,cfftp,cfimage,cfldap,cflog,cfparam,cfpop,cfprint,cfquery,cfqueryparam,cfprocparam,cfhttp,cfhttpparam,cfoutput,cfinvokeargument,cfsetting,cfprocessingdirective,cfmailparam,cflogout,cfloginuser,cftimer,cftrace,cfthread", tag.getName())) {
 			//do generic CF11+ conversion
 			return toScriptGeneric(tag);
 		}

--- a/converters/cffunction.cfc
+++ b/converters/cffunction.cfc
@@ -40,7 +40,9 @@ component extends="BaseConverter" {
 			s = s & "public ";
 		}
 		if (structKeyExists(attr, "returntype")) {
-			s = s & attr.returntype & " ";
+			if( !variables.options.cleanTypes || ( attr.returntype != "VOID" && attr.returntype != "any" ) ) {
+				s = s & attr.returntype & " ";
+			}
 		}
 		s = s & "function " & attr.name & "(";
 
@@ -56,7 +58,9 @@ component extends="BaseConverter" {
 					s = s & "required ";
 				}
 				if (structKeyExists(childAttr, "type")) {
-					s = s & childAttr.type & " ";
+					if( !variables.options.cleanTypes || ( childAttr.type != "VOID" && childAttr.type != "any" ) ) {
+						s = s & childAttr.type & " ";
+					}
 				}
 				s = s & childAttr.name;
 				if (structKeyExists(childAttr, "default")) {

--- a/converters/cflock.cfc
+++ b/converters/cflock.cfc
@@ -1,6 +1,9 @@
 component extends="BaseConverter" {
 	
 	public string function toScript(tag) {
+		if( !tag.hasInnerContent() ) {
+			throw(message="cflock tag have a start and end tag");
+		}
 		var s = "lock ";
 		var attr = tag.getAttributes();
 		s = s & trim(tag.getAttributeContent(stripTrailingSlash=true));

--- a/converters/cfloop.cfc
+++ b/converters/cfloop.cfc
@@ -47,6 +47,18 @@ component extends="BaseConverter" {
 				s = s & "++";
 			}
 			s = s & " ) {";
+		} else if (structKeyExists(attr, "query")) {
+			s = "cfloop( query= " & attr.query;
+			if (structKeyExists(attr, "startrow")) {
+				s = s & " startRow= " & unPound(attr.startrow);
+			}
+			if (structKeyExists(attr, "endrow")) {
+				s = s & " endRow= " & unPound(attr.endrow);
+			}
+			if (structKeyExists(attr, "maxrows")) {
+				s = s & " maxRows= " & unPound(attr.maxrows);
+			}
+			s = s & " ) {";
 		} else {
 			throw(message="Unimplemented cfloop condition: #tag.getAttributeContent()# ");
 		}

--- a/converters/cfset.cfc
+++ b/converters/cfset.cfc
@@ -1,6 +1,7 @@
 component extends="BaseConverter" {
 
 	public string function toScript(tag) {
-		return trim(convertOperators(tag.getAttributeContent(stripTrailingSlash=true))) & ";"; 
+		var i = variables.toscript.getIdentLevel();
+		return reReplace( trim(convertOperators(tag.getAttributeContent(stripTrailingSlash=true))) & ";", "\n\t", chr(10) & repeatString( variables.options.indentChars, i ), "all" ); 
 	}
 }

--- a/converters/cftimer.cfc
+++ b/converters/cftimer.cfc
@@ -1,0 +1,10 @@
+component extends="BaseBlockTagConverter" {
+
+	public string function toScript(tag) {
+		if( !tag.hasInnerContent() ) {
+			throw(message="cftimer tag have a start and end tag");
+		}
+		return super.toScript(tag);
+	}
+
+}


### PR DESCRIPTION
This pull will re-indent multiline cfset content. It was necessary to pass the toscript object to the converter and add a public method to get the current ident level.

For example the tags:
```
<cffunction>
	<cfset var foo = {
		success = false
	,	something = ""
	}>
</cffunction>
```

Would previously result in:
```
function {
	foo = {
	success = false
,	something = ""
};
}
```

After this pull it will be:
```
function {
	foo = {
		success = false
	,	something = ""
	};
}
```

