### PR TITLE
Add support for function argument hints

### DIFF
--- a/converters/BaseConverter.cfc
+++ b/converters/BaseConverter.cfc
@@ -81,4 +81,12 @@ component {
 		return Chr(13) & Chr(10);
 	}
 
+	public string function startJavaDocs() {
+		return "/" & "**" & getJavaDocsNewLine();
+	}
+
+	public string function getJavaDocsNewLine() {
+		return getLineBreak() & getIndentChars() & " *";
+	}
+
 }

--- a/converters/BaseConverter.cfc
+++ b/converters/BaseConverter.cfc
@@ -81,16 +81,28 @@ component {
 		return Chr(13) & Chr(10);
 	}
 
-	public string function startJavaDocs() {
-		return "/" & "**" & getJavaDocsNewLine();
+	public string function startJavaDocs(boolean indent = false) {
+		return "/" & "**" & getJavaDocsNewLine(arguments.indent);
 	}
 
-	public string function getJavaDocsNewLine() {
-		return getLineBreak() & getIndentChars() & " *";
+	public string function getJavaDocsNewLine(boolean indent = false) {
+		var newLine = getLineBreak();
+
+		if (arguments.indent) {
+			newLine &= getIndentChars();
+		}
+
+		return newLine & " *";
 	}
 
-	public string function endJavaDocs() {
-		return "/" & getLineBreak();
+	public string function endJavaDocs(boolean indent = false) {
+		var ending = "/" & getLineBreak();
+
+		if (arguments.indent) {
+			ending &= getIndentChars();
+		}
+
+		return ending;
 	}
 
 }

--- a/converters/BaseConverter.cfc
+++ b/converters/BaseConverter.cfc
@@ -89,4 +89,8 @@ component {
 		return getLineBreak() & getIndentChars() & " *";
 	}
 
+	public string function endJavaDocs() {
+		return "/" & getLineBreak();
+	}
+
 }

--- a/converters/cfcomponent.cfc
+++ b/converters/cfcomponent.cfc
@@ -5,11 +5,11 @@ component extends="BaseConverter" {
 		var attr = tag.getAttributes();
 		
 		if (structKeyExists(attr, "hint")) {
-			s = "/" & "**" & getLineBreak() & " * " & attr.hint & getLineBreak() & " *";
+			s = startJavaDocs() & " " & attr.hint & getJavaDocsNewLine();
 		}
 		
 		if (len(s)) {
-			s = s & "/" & getLineBreak();
+			s = s & endJavaDocs();
 		}
 		s = s & "component ";
 		if (tag.hasAttributes()) {

--- a/converters/cffunction.cfc
+++ b/converters/cffunction.cfc
@@ -16,7 +16,7 @@ component extends="BaseConverter" {
 		}
 		// build javadocs to prepend later
 		if (structKeyExists(attr, "hint")) {
-			javaDocs = "/" & "**" & getLineBreak() & getIndentChars() & " * " & attr.hint & getLineBreak() & getIndentChars() & " *";
+			javaDocs = startJavaDocs() & " " & attr.hint & getJavaDocsNewLine();
 		}
 		for (a in attr) {
 			if (listFindNoCase(additionalArgs, a)) {
@@ -27,10 +27,9 @@ component extends="BaseConverter" {
 				continue;
 			} else {
 				if (len(javaDocs) == 0) {
-					/* */
-					javaDocs = "/" & "**" & getLineBreak() & getIndentChars() & " *";
+					javaDocs = startJavaDocs();
 				}
-				javaDocs = javaDocs & " @" & a & " " & attr[a] & getLineBreak() & getIndentChars() & " *";
+				javaDocs = javaDocs & " @" & a & " " & attr[a] & getJavaDocsNewLine();
 			}
 		}
 		if (structKeyExists(attr, "access")) {
@@ -63,7 +62,10 @@ component extends="BaseConverter" {
 				}
 				// add hint to javaDocs
 				if (structKeyExists(childAttr, "hint")) {
-					javaDocs = javaDocs & " @" & childAttr.name & " " & childAttr.hint & getLineBreak() & getIndentChars() & " *";
+					if (len(javaDocs) == 0) {
+						javaDocs = startJavaDocs();
+					}
+					javaDocs = javaDocs & " @" & childAttr.name & " " & childAttr.hint & getJavaDocsNewLine();
 				}
 			}
 		}
@@ -81,6 +83,14 @@ component extends="BaseConverter" {
 			s = javaDocs & s;
 		}
 		return s;
+	}
+
+	private string function startJavaDocs() {
+		return "/" & "**" & getJavaDocsNewLine();
+	}
+
+	private string function getJavaDocsNewLine() {
+		return getLineBreak() & getIndentChars() & " *";
 	}
 
 	public boolean function indentBody(tag) {

--- a/converters/cffunction.cfc
+++ b/converters/cffunction.cfc
@@ -85,14 +85,6 @@ component extends="BaseConverter" {
 		return s;
 	}
 
-	private string function startJavaDocs() {
-		return "/" & "**" & getJavaDocsNewLine();
-	}
-
-	private string function getJavaDocsNewLine() {
-		return getLineBreak() & getIndentChars() & " *";
-	}
-
 	public boolean function indentBody(tag) {
 		return true;
 	}

--- a/converters/cffunction.cfc
+++ b/converters/cffunction.cfc
@@ -2,6 +2,7 @@ component extends="BaseConverter" {
 	
 	public string function toScript(tag) {
 		var s = "";
+		var javaDocs = "";
 		var attr = tag.getAttributes();
 		var childAttr = "";
 		var children = tag.getChildren();
@@ -13,8 +14,9 @@ component extends="BaseConverter" {
 		if (!tag.hasAttributes()) {
 			throw(message="cffunction must have attributes");
 		}
+		// build javadocs to prepend later
 		if (structKeyExists(attr, "hint")) {
-			s = "/" & "**" & getLineBreak() & getIndentChars() & " * " & attr.hint & getLineBreak() & getIndentChars() & " *";
+			javaDocs = "/" & "**" & getLineBreak() & getIndentChars() & " * " & attr.hint & getLineBreak() & getIndentChars() & " *";
 		}
 		for (a in attr) {
 			if (listFindNoCase(additionalArgs, a)) {
@@ -24,15 +26,12 @@ component extends="BaseConverter" {
 				//ignore these they go elsewhere
 				continue;
 			} else {
-				if (len(s) == 0) {
+				if (len(javaDocs) == 0) {
 					/* */
-					s = "/" & "**" & getLineBreak() & getIndentChars() & " *";
+					javaDocs = "/" & "**" & getLineBreak() & getIndentChars() & " *";
 				}
-				s = s & " @" & a & " " & attr[a] & getLineBreak() & getIndentChars() & " *";
+				javaDocs = javaDocs & " @" & a & " " & attr[a] & getLineBreak() & getIndentChars() & " *";
 			}
-		}
-		if (len(s)) {
-			s = s & "/" & getLineBreak() & getIndentChars();
 		}
 		if (structKeyExists(attr, "access")) {
 			s = s & attr.access & " ";
@@ -62,7 +61,10 @@ component extends="BaseConverter" {
 				if (structKeyExists(childAttr, "default")) {
 					s = s & "=""" & childAttr.default & """"; 
 				}
-				
+				// add hint to javaDocs
+				if (structKeyExists(childAttr, "hint")) {
+					javaDocs = javaDocs & " @" & childAttr.name & " " & childAttr.hint & getLineBreak() & getIndentChars() & " *";
+				}
 			}
 		}
 		s = s & ")";
@@ -72,8 +74,12 @@ component extends="BaseConverter" {
 				s = s & " " & a & "=" & unPound(attr[a]);
 			}
 		}
-
 		s = s & " {";
+		// close and prepend javadocs, if any
+		if (len(javaDocs)) {
+			javaDocs = javaDocs & "/" & getLineBreak() & getIndentChars();
+			s = javaDocs & s;
+		}
 		return s;
 	}
 

--- a/converters/cffunction.cfc
+++ b/converters/cffunction.cfc
@@ -16,7 +16,7 @@ component extends="BaseConverter" {
 		}
 		// build javadocs to prepend later
 		if (structKeyExists(attr, "hint")) {
-			javaDocs = startJavaDocs() & " " & attr.hint & getJavaDocsNewLine();
+			javaDocs = startJavaDocs(indent = true) & " " & attr.hint & getJavaDocsNewLine(indent = true);
 		}
 		for (a in attr) {
 			if (listFindNoCase(additionalArgs, a)) {
@@ -27,9 +27,9 @@ component extends="BaseConverter" {
 				continue;
 			} else {
 				if (len(javaDocs) == 0) {
-					javaDocs = startJavaDocs();
+					javaDocs = startJavaDocs(indent = true);
 				}
-				javaDocs = javaDocs & " @" & a & " " & attr[a] & getJavaDocsNewLine();
+				javaDocs = javaDocs & " @" & a & " " & attr[a] & getJavaDocsNewLine(indent = true);
 			}
 		}
 		if (structKeyExists(attr, "access")) {
@@ -63,9 +63,9 @@ component extends="BaseConverter" {
 				// add hint to javaDocs
 				if (structKeyExists(childAttr, "hint")) {
 					if (len(javaDocs) == 0) {
-						javaDocs = startJavaDocs();
+						javaDocs = startJavaDocs(indent = true);
 					}
-					javaDocs = javaDocs & " @" & childAttr.name & " " & childAttr.hint & getJavaDocsNewLine();
+					javaDocs = javaDocs & " @" & childAttr.name & " " & childAttr.hint & getJavaDocsNewLine(indent = true);
 				}
 			}
 		}
@@ -79,7 +79,7 @@ component extends="BaseConverter" {
 		s = s & " {";
 		// close and prepend javadocs, if any
 		if (len(javaDocs)) {
-			javaDocs = javaDocs & endJavaDocs() & getIndentChars();
+			javaDocs = javaDocs & endJavaDocs(indent = true);
 			s = javaDocs & s;
 		}
 		return s;

--- a/converters/cffunction.cfc
+++ b/converters/cffunction.cfc
@@ -79,7 +79,7 @@ component extends="BaseConverter" {
 		s = s & " {";
 		// close and prepend javadocs, if any
 		if (len(javaDocs)) {
-			javaDocs = javaDocs & "/" & getLineBreak() & getIndentChars();
+			javaDocs = javaDocs & endJavaDocs() & getIndentChars();
 			s = javaDocs & s;
 		}
 		return s;

--- a/tests/tests/GeneratedScriptCode.cfc
+++ b/tests/tests/GeneratedScriptCode.cfc
@@ -211,6 +211,10 @@ component extends="testbox.system.BaseSpec" {
 		$assert.isEqual(add(6,1), 7, "Testing unnamed arguments");
 	}
 
+	/**
+	 * @a First number to add
+	 * @b Second number to add
+	 */
 	private numeric function add(numeric a="5", numeric b="3") {
 		return arguments.a + arguments.b;
 	}

--- a/tests/tests/GeneratedScriptCode.cfc
+++ b/tests/tests/GeneratedScriptCode.cfc
@@ -4,7 +4,10 @@
 
 	This test will require CF11+ or Lucee 4.5+
 */
-component extends="testbox.system.BaseSpec" {
+/**
+ * Template for testing Tag to Script conversion
+ */
+component extends="testbox.system.BaseSpec" hint="Template for testing Tag to Script conversion" {
 	property name="testProperty" default="Bacon";
 
 	public function testFunction() {
@@ -205,6 +208,9 @@ component extends="testbox.system.BaseSpec" {
 		}
 	}
 
+	/**
+	 * Test function arguments with defaults, named and unnamed
+	 */
 	public function testArguments() {
 		$assert.isEqual(add(), 8, "Testing arg defaults");
 		$assert.isEqual(add(a=3, b=2), 5, "Testing named arguments");

--- a/tests/tests/TagTemplate.cfc
+++ b/tests/tests/TagTemplate.cfc
@@ -4,7 +4,7 @@
 
 	This test will require CF11+ or Lucee 4.5+
 --->
-<cfcomponent extends="testbox.system.BaseSpec">
+<cfcomponent extends="testbox.system.BaseSpec" hint="Template for testing Tag to Script conversion">
 			
 	<cfproperty name="testProperty" default="Bacon">
 
@@ -209,7 +209,7 @@
 		
 	</cffunction>
 
-	<cffunction name="testArguments">
+	<cffunction name="testArguments" hint="Test function arguments with defaults, named and unnamed">
 		<cfset $assert.isEqual(add(), 8, "Testing arg defaults")>
 		<cfset $assert.isEqual(add(a=3, b=2), 5, "Testing named arguments")>
 		<cfset $assert.isEqual(add(6,1), 7, "Testing unnamed arguments")>

--- a/tests/tests/TagTemplate.cfc
+++ b/tests/tests/TagTemplate.cfc
@@ -216,8 +216,8 @@
 	</cffunction>
 
 	<cffunction name="add" access="private" returntype="numeric">
-		<cfargument name="a" default="5" type="numeric">
-		<cfargument name="b" default="3" type="numeric">
+		<cfargument name="a" default="5" type="numeric" hint="First number to add">
+		<cfargument name="b" default="3" type="numeric" hint="Second number to add">
 		<cfreturn arguments.a + arguments.b>
 	</cffunction>
 


### PR DESCRIPTION
This PR adds argument hints to the parent function's javadocs.  

Changes: 

1. Updates cffunction.cfc to separate the javadocs from the rest of the function so we can inject argument hints.
2. Adds some javadocs-specific methods to BaseConverter.cfc 
3. Updates cffunction.cfc and components.cfc to use the new javadocs methods.
4. Updates TagTemplate.cfc to include some hints for testing.

Relates to [Issue #34](https://github.com/foundeo/toscript/issues/34)